### PR TITLE
Webpack 설정 파일 production, development 분리

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,12 @@ module.exports = {
         labelAttributes: ['htmlFor'],
       },
     ],
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: ['**/webpack.*.js'],
+      },
+    ],
   },
   globals: {
     figma: true,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "webpack",
+    "start": "webpack --config webpack.dev.js --watch",
+    "build": "webpack --config webpack.prod.js",
     "lint": "eslint src/**/*.{js,jsx}",
     "lint:fix": "eslint --fix 'src/**/*.{js,jsx}'",
     "format": "prettier --write 'src/**/*.{js,jsx,css}'",
@@ -35,7 +36,8 @@
     "react-dev-utils": "^12.0.1",
     "style-loader": "^3.3.1",
     "webpack": "^5.75.0",
-    "webpack-cli": "^5.0.1"
+    "webpack-cli": "^5.0.1",
+    "webpack-merge": "^5.8.0"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -40,6 +40,7 @@ module.exports = {
       template: './src/ui.html',
       filename: 'ui.html',
       chunks: ['ui'],
+      cache: false,
     }),
     new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/ui/]),
   ],

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,10 +5,6 @@ const path = require('path');
 const webpack = require('webpack');
 
 module.exports = {
-  mode: 'development',
-
-  devtool: 'inline-source-map',
-
   entry: {
     ui: './src/ui.jsx',
     code: './src/code.js',

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,0 +1,7 @@
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common');
+
+module.exports = merge(common, {
+  mode: 'development',
+  devtool: 'inline-source-map',
+});

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,6 @@
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common');
+
+module.exports = merge(common, {
+  mode: 'production',
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3652,7 +3652,7 @@ webpack-cli@^5.0.1:
     rechoir "^0.8.0"
     webpack-merge "^5.7.3"
 
-webpack-merge@^5.7.3:
+webpack-merge@^5.7.3, webpack-merge@^5.8.0:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.8.0.tgz#2b39dbf22af87776ad744c390223731d30a68f61"
   integrity sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==


### PR DESCRIPTION
`yarn build` 스크립트 실행 시에는 플러그인 재실행 시 코드 변경 사항이 잘 반영되는데,
`yarn start` 스크립트 실행 시에는 플러그인을 재실행해도 코드 변경 사항이 반영되지 않는 문제가 있습니다.

해결 &rarr; HtmlWebpackPlugin cache 옵션을 false 로 변경
```
plugins: [
    ...
    new HtmlWebpackPlugin({
      ...
      cache: false,
    }),
],
```