### PR TITLE
전체 체크 박스 버그 수정

### DIFF
--- a/src/store/result/index.js
+++ b/src/store/result/index.js
@@ -9,7 +9,6 @@ export const {
 } = resultSlice.actions;
 export const {
   resultSelector,
-  resultCountSelector,
   resultListSelector,
   selectedResultCountSelector,
 } = selector;

--- a/src/store/result/selector.js
+++ b/src/store/result/selector.js
@@ -2,12 +2,6 @@ import { createSelector } from '@reduxjs/toolkit';
 
 export const resultSelector = (state) => state.resultReducer;
 
-export const resultCountSelector = createSelector(
-  resultSelector,
-  (state) =>
-    state.resultList.length + state.resultWithMultipleRecommendList.length
-);
-
 export const resultListSelector = createSelector(
   resultSelector,
   (state) => state.resultList

--- a/src/views/result/resultVM.js
+++ b/src/views/result/resultVM.js
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { useAppDispatch, useAppSelector } from '@store/hook';
 import {
   convertListenerConnect,
-  resultCountSelector,
+  resultSelector,
   toggleAllResultSelection,
 } from '@store/result';
 import { selectedResultCountSelector } from '@store/result/selector';
@@ -14,8 +14,13 @@ export const useResultVM = () => {
   const dispatch = useAppDispatch();
   const { clear } = usePageRouter();
 
-  const resultCount = useAppSelector(resultCountSelector);
+  const { resultList, resultWithMultipleRecommendList } =
+    useAppSelector(resultSelector);
   const selectedResultCount = useAppSelector(selectedResultCountSelector);
+
+  const resultCount = useMemo(() => {
+    return resultList.length + resultWithMultipleRecommendList.length;
+  }, [resultList, resultWithMultipleRecommendList]);
 
   const isResultEmpty = useMemo(() => {
     return resultCount === 0;
@@ -26,8 +31,8 @@ export const useResultVM = () => {
   }, [selectedResultCount]);
 
   const isAllResultSelected = useMemo(() => {
-    return resultCount === selectedResultCount;
-  }, [resultCount, selectedResultCount]);
+    return resultList.length === selectedResultCount;
+  }, [resultList, selectedResultCount]);
 
   const toggleCheckAll = (isChecked) => {
     dispatch(toggleAllResultSelection(isChecked));


### PR DESCRIPTION
에러 상황
- 체크를 해제해도 전체 선택이 풀리지 않음
- 개별 체크를 통해 모든 체크박스를 선택해도 전체 선택 체크박스가 체크되지 않음

해결 방법
- Result Store 에서 맞춤법 검사 결과를 resultList, resultWithMultipleRecommendList 두 개로 들고 있었는데
  selectedResultCount 를 이 두 리스트의 길이를 합친 것과 비교하고 있었습니다.
- 기획 상으로는 resultList 만 체크할 수 있으므로, selectedResultCount 를 resultList 의 길이하고만 비교하도록 수정하여 버그를 해결했습니다.